### PR TITLE
Update Numeric.js

### DIFF
--- a/accessory/characteristic/Numeric.js
+++ b/accessory/characteristic/Numeric.js
@@ -7,7 +7,7 @@ const NUMERIC_CONFIG = {
 };
 
 function addNumericSensorCharacteristic(service, characteristic, CONF_MAP, optional) {
-    addNumericSensorCharacteristicWithTransformation(service, characteristic, CONF_MAP, parseFloat, optional);
+    addNumericSensorCharacteristicWithTransformation.bind(this)(service, characteristic, CONF_MAP, parseFloat, optional);
 }
 
 function addNumericSensorCharacteristicWithTransformation(service, characteristic, CONF_MAP, transformation, optional) {


### PR DESCRIPTION
Fixed commit 4c3b985 for Thermostat, Door and Humidity.

```
[9/15/2019, 12:50:49 PM] [openHAB2-Complete] Loading accessories from configuration, this might take a while...
[9/15/2019, 12:50:50 PM] [openHAB2-Complete] Unable to add accessory Pogoda wilgotność: TypeError: Cannot read property 'name' of undefined, skipping
HAP Warning: Characteristic 00000024-0000-1000-8000-0026BB765291 not in required or optional characteristics for service 00000041-0000-1000-8000-0026BB765291. Adding anyway.
[9/15/2019, 12:50:50 PM] [openHAB2-Complete] Unable to add accessory Bramka: ReferenceError: addNotificationTextCharacteristic is not defined, skipping
[9/15/2019, 12:50:50 PM] [openHAB2-Complete] Unable to add accessory Ciepła woda temp.: TypeError: Cannot read property 'name' of undefined, skipping
[9/15/2019, 12:50:50 PM] [openHAB2-Complete] Unable to add accessory Przedpokój mały temp.: TypeError: Cannot read property 'name' of undefined, skipping
[9/15/2019, 12:50:50 PM] [openHAB2-Complete] Unable to add accessory Przedpokój duży temp.: TypeError: Cannot read property 'name' of undefined, skipping
[9/15/2019, 12:50:50 PM] [openHAB2-Complete] Unable to add accessory Pokój temp.: TypeError: Cannot read property 'name' of undefined, skipping
[9/15/2019, 12:50:50 PM] [openHAB2-Complete] Unable to add accessory Salon temp.: TypeError: Cannot read property 'name' of undefined, skipping
[9/15/2019, 12:50:50 PM] [openHAB2-Complete] Unable to add accessory Jadalnia temp.: TypeError: Cannot read property 'name' of undefined, skipping
[9/15/2019, 12:50:50 PM] [openHAB2-Complete] Unable to add accessory Kuchnia temp.: TypeError: Cannot read property 'name' of undefined, skipping
[9/15/2019, 12:50:50 PM] [openHAB2-Complete] Unable to add accessory Łazienka parter temp.: TypeError: Cannot read property 'name' of undefined, skipping
[9/15/2019, 12:50:50 PM] [openHAB2-Complete] Unable to add accessory Garderoba temp.: TypeError: Cannot read property 'name' of undefined, skipping
[9/15/2019, 12:50:50 PM] [openHAB2-Complete] Unable to add accessory Biuro temp.: TypeError: Cannot read property 'name' of undefined, skipping
[9/15/2019, 12:50:50 PM] [openHAB2-Complete] Unable to add accessory Kamila temp.: TypeError: Cannot read property 'name' of undefined, skipping
[9/15/2019, 12:50:50 PM] [openHAB2-Complete] Unable to add accessory Sypialnia temp.: TypeError: Cannot read property 'name' of undefined, skipping
[9/15/2019, 12:50:50 PM] [openHAB2-Complete] Unable to add accessory Łazienka piętro temp.: TypeError: Cannot read property 'name' of undefined, skipping
```