### PR TITLE
Fixed issue #71 by handling exceptions in isOnline

### DIFF
--- a/util/OpenHAB.js
+++ b/util/OpenHAB.js
@@ -63,10 +63,15 @@ class OpenHAB {
     }
 
     isOnline() {
-        let myURL = this._getURL(`/rest/items`);
-        const response = syncRequest('GET', myURL);
-        this._log.debug(`Online request for openHAB (${myURL}) resulted in status code ${response.statusCode}`);
-        return response.statusCode === 200;
+        try {
+          let myURL = this._getURL(`/rest/items`);
+          const response = syncRequest('GET', myURL);
+          this._log.debug(`Online request for openHAB (${myURL}) resulted in status code ${response.statusCode}`);
+          return response.statusCode === 200;
+        } catch (e) {
+          this._log.warn(`Unable to retrieve openHAB URL ${myURL}: ${e}`);
+          return false;
+        }
     }
 
     getState(habItem, callback) {


### PR DESCRIPTION
This should fix the crashes that happen e.g. when the machine running openHAB does not accept http connections. See issue #71