### PR TITLE
Add Contact Itemtype for Lock Mechanism stateItem

### DIFF
--- a/README.md
+++ b/README.md
@@ -872,7 +872,7 @@ The HomeKit Lock Mechanism service is designed to expose and control the physica
   * Default: `"false"`
   * Allowed values: `"true"` & `"false"` *don't forget the quotes*
 * `stateItem` *(optional)*: The openHAB item, used to determine the state of the lock instead of `item`'s state
-  * Needs to be of type `Rollershutter`, `Number`, `Switch` or `Contact` within openHAB
+  * Needs to be of type `Switch` or `Contact` within openHAB
 * `stateItemInverted` *(optional)*: If `stateItem`'s state needs to be interpreted inverted, set this value to `"true"` 
   * Default: `"false"`
   * Allowed values: `"true"` & `"false"` *don't forget the quotes*

--- a/accessory/characteristic/CurrentTargetLock.js
+++ b/accessory/characteristic/CurrentTargetLock.js
@@ -12,7 +12,7 @@ const CURRENT_TARGET_LOCK_CONFIG = {
 function addCurrentLockStateCharacteristic(service) {
     let item, itemType, inverted;
     if(this._config[CURRENT_TARGET_LOCK_CONFIG.stateItem]) {
-        [item, itemType] = this._getAndCheckItemType(CURRENT_TARGET_LOCK_CONFIG.stateItem, ['Switch']);
+        [item, itemType] = this._getAndCheckItemType(CURRENT_TARGET_LOCK_CONFIG.stateItem, ['Switch', 'Contact']);
         inverted = this._checkInvertedConf(CURRENT_TARGET_LOCK_CONFIG.stateItemInverted);
     } else {
         [item, itemType] = this._getAndCheckItemType(CURRENT_TARGET_LOCK_CONFIG.item, ['Switch']);
@@ -27,7 +27,7 @@ function addTargetLockStateCharacteristic(service) {
     let stateItem, stateItemType, stateItemInverted;
 
     if(this._config[CURRENT_TARGET_LOCK_CONFIG.stateItem]) {
-        [stateItem, stateItemType] = this._getAndCheckItemType(CURRENT_TARGET_LOCK_CONFIG.stateItem, ['Switch']);
+        [stateItem, stateItemType] = this._getAndCheckItemType(CURRENT_TARGET_LOCK_CONFIG.stateItem, ['Switch', 'Contact']);
         stateItemInverted = this._checkInvertedConf(CURRENT_TARGET_LOCK_CONFIG.stateItemInverted);
     } else {
         stateItem = item;
@@ -44,6 +44,8 @@ function lockStateTransformation(type, inverted, value) {
     const transformation = {
         "ON": inverted ? UNSECURED : SECURED,
         "OFF": inverted ? SECURED : UNSECURED,
+        "OPEN": inverted ? SECURED : UNSECURED,
+        "CLOSED": inverted ? UNSECURED : SECURED,
         [UNSECURED]: inverted ? "ON" : "OFF",
         [SECURED ]: inverted ? "OFF" : "ON"
     };


### PR DESCRIPTION
The documentations mentioned that a lot of item types are supported for stateItem on Lock Mechanism. But that is currently not implemented. This PR adds Contact as supported item type for stateItem and modifies the readme.