### PR TITLE
Add explicit Content-Type for sendCommand

### DIFF
--- a/util/OpenHAB.js
+++ b/util/OpenHAB.js
@@ -142,7 +142,10 @@ class OpenHAB {
         request({
             url: myURL,
             method: 'POST',
-            body: command
+            body: command,
+            headers: {
+                'Content-Type': 'text/plain'
+            }
         },
         function(error, response) {
             if(error) {


### PR DESCRIPTION
Fix for https://github.com/steilerDev/homebridge-openhab2-complete/issues/87