### PR TITLE
Cooling only Heater Cooler fix

### DIFF
--- a/accessory/characteristic/ClimateHeaterCooler.js
+++ b/accessory/characteristic/ClimateHeaterCooler.js
@@ -122,7 +122,7 @@ function _getHeaterCoolerState(mode, heatingItem, coolingItem, callback) {
             }, callback);
             break;
         case "cooling":
-            getState.bind(this, coolingItem, {
+            getState.bind(this)(coolingItem, {
                 "ON": COOLING,
                 "OFF": IDLE
             }, callback);

--- a/accessory/characteristic/ClimateHeaterCooler.js
+++ b/accessory/characteristic/ClimateHeaterCooler.js
@@ -74,6 +74,13 @@ function addTargetHeaterCoolerStateCharacteristic(service) {
                 callback(null, mode);
             })
             .on('set', function(_, callback) { callback() }.bind(this));
+
+        if (mode == HEAT || mode == COOL) {
+            service.getCharacteristic(this.Characteristic.TargetHeaterCoolerState).setProps({
+                minValue: mode,
+                maxValue: mode
+            });
+        }
     }
 }
 


### PR DESCRIPTION
Typo in ClimateHeaterCooler.js line 125

Solves issue with "cooling only" Heater/Cooler error:
This plugin slows down Homebridge. The read handler for the characteristic 'Current Heater-Cooler State' didn't respond at all!. Please check that you properly call the callback! See https://homebridge.io/w/JtMGR for more info.