### PR TITLE
Misc. fixes on humidifier / dehumidifier

### DIFF
--- a/accessory/characteristic/ClimateDeHumidifier.js
+++ b/accessory/characteristic/ClimateDeHumidifier.js
@@ -76,6 +76,13 @@ function addTargetHumidifierDehumidifierStateCharacteristic(service) {
                 callback(null, mode);
             })
             .on('set', function(_, callback) { callback() }.bind(this));
+
+        if (mode == HUMIDIFIER || mode == DEHUMIDIFIER) {
+            service.getCharacteristic(this.Characteristic.TargetHumidifierDehumidifierState).setProps({
+                minValue: mode,
+                maxValue: mode
+            });
+        }
     }
 }
 
@@ -83,7 +90,7 @@ function _transformHumidifierDehumidifierState(thisItemMode, characteristic, val
     let INACTIVE = 0;       // = Characteristic.CurrentHumidifierDehumidifierState.INACTIVE
     let IDLE = 1;           // = Characteristic.CurrentHumidifierDehumidifierState.IDLE
     let HUMIDIFYING = 2;    // = Characteristic.CurrentHumidifierDehumidifierState.HUMIDIFYING
-    let DEHUMIDIFYING = 2;  // = Characteristic.CurrentHumidifierDehumidifierState.DEHUMIDIFYING
+    let DEHUMIDIFYING = 3;  // = Characteristic.CurrentHumidifierDehumidifierState.DEHUMIDIFYING
 
     let currentState = characteristic.value;
 
@@ -124,7 +131,7 @@ function _getHumidifierDehumidifierState(mode, humidifierItem, dehumidifierItem,
             }, callback);
             break;
         case "dehumidify":
-            getState.bind(this, dehumidifierItem, {
+            getState.bind(this)(dehumidifierItem, {
                 "ON": DEHUMIDIFYING,
                 "OFF": IDLE
             }, callback);


### PR DESCRIPTION
1. Hide unnecessary modes For humidifier-only and dehumidifier-only modes, limit mode value to the actual mode. This makes the widget more consistent by not showing humidify / dehumidify / Automatic modes for a dehumifidier-only device.

2. Wrong DEHUMIDIFYING value in _transformHumidifierDehumidifierState Typo fixed

3. Incorrect syntax for dehumidify case in _getHumidifierDehumidifierState Typo fixed